### PR TITLE
Allow tildes as well as three backticks for fenced code blocks

### DIFF
--- a/lib/minidown/document.rb
+++ b/lib/minidown/document.rb
@@ -90,7 +90,7 @@ module Minidown
         indent, str = $1.size, $2
         inblock{ol str, indent}
       when regexp[:code_block] =~ line
-        # ```
+        # ``` or ~~~
         code_block $1
       when !@inblock && pre_blank? && regexp[:indent_code] =~ line
         #    code

--- a/lib/minidown/utils.rb
+++ b/lib/minidown/utils.rb
@@ -8,7 +8,7 @@ module Minidown
       start_with_quote: /\A\>\s*(.+)/,
       unorder_list: /\A(\s*)[*\-+]\s+(.+)/,
       order_list: /\A(\s*)\d+\.\s+(.+)/,
-      code_block: /\A\s*(?:`{3}|~{3,})\s*(\S*)/,
+      code_block: /\A\s*[`~]{3,}\s*(\S*)/,
       dividing_line: /\A(\s*[*-]\s*){3,}\z/,
       indent_code: /\A\s{4}(.+)/
     }

--- a/lib/minidown/utils.rb
+++ b/lib/minidown/utils.rb
@@ -8,7 +8,7 @@ module Minidown
       start_with_quote: /\A\>\s*(.+)/,
       unorder_list: /\A(\s*)[*\-+]\s+(.+)/,
       order_list: /\A(\s*)\d+\.\s+(.+)/,
-      code_block: /\A\s*`{3}\s*(\S*)/,
+      code_block: /\A\s*(?:`{3}|~{3,})\s*(\S*)/,
       dividing_line: /\A(\s*[*-]\s*){3,}\z/,
       indent_code: /\A\s{4}(.+)/
     }

--- a/spec/code_block_spec.rb
+++ b/spec/code_block_spec.rb
@@ -14,6 +14,30 @@ HERE
         Minidown.parse(str).to_html.should == "<pre><code>should in code block\n\nin block</code></pre>"
       end
       
+      it 'should allow tildes as well as backquotes' do
+        str =<<HERE
+~~~
+should in code block
+
+in block
+~~~
+HERE
+        Minidown.parse(str).to_html.should == "<pre><code>should in code block\n\nin block</code></pre>"
+      end
+
+
+      it 'should allow arbitrary number of tildes' do
+        str =<<HERE
+~~~~~~~~~~~
+should in code block
+
+in block
+~~~~~~~~~~~
+HERE
+        Minidown.parse(str).to_html.should == "<pre><code>should in code block\n\nin block</code></pre>"
+      end
+        
+      
       it 'should ignore space' do
         str =<<HERE
   ```
@@ -31,6 +55,17 @@ should in code block
 
 in block
 ```
+HERE
+        Minidown.parse(str).to_html.should == "<pre lang=\"ruby\"><code>should in code block\n\nin block</code></pre>"
+      end
+
+      it 'should have lang attribute with tildes' do
+        str =<<HERE
+~~~  ruby
+should in code block
+
+in block
+~~~
 HERE
         Minidown.parse(str).to_html.should == "<pre lang=\"ruby\"><code>should in code block\n\nin block</code></pre>"
       end


### PR DESCRIPTION
Lots of markdown floating around uses tildes (~) as the fenced code block delimiter. This minor change allows that. Simple specs included.
